### PR TITLE
Feat: Add db_init to app postgres config in helm chart

### DIFF
--- a/chart/gig3r/templates/_helpers.tpl
+++ b/chart/gig3r/templates/_helpers.tpl
@@ -45,7 +45,8 @@ false
     "username": "{{ .Values.database.user }}",
     "password": "{{ .Values.database.password }}",
     "host": "postgres-postgresql.postgres.svc.cluster.local",
-    "database": "{{ .Values.database.name }}"
+    "database": "{{ .Values.database.name }}",
+    "db_init": false
   },
   "flask": {
     "host": "{{ include "gig3r.host" . }}",


### PR DESCRIPTION
Adds missing field postgres.db_init as `false`